### PR TITLE
Use performance.now where available.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@ module.exports = raf
 
 var EE = require('events').EventEmitter
   , global = typeof window === 'undefined' ? this : window
-  , now = Date.now || function () { return +new Date() }
+  , now = global.performance && global.performance.now ? function() {
+    return performance.now()
+  } : Date.now || function () {
+    return +new Date()
+  }
 
 var _raf =
   global.requestAnimationFrame ||


### PR DESCRIPTION
requestAnimationFrame now returns [sub-millisecond timestamps](http://updates.html5rocks.com/2012/05/requestAnimationFrame-API-now-with-sub-millisecond-precision) in Chrome - you can get the same timestamps from `performance.now`, and it makes a difference when there's only supposed to be 16.7ms between frames :)
