### PR TITLE
Fixed `resume`

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,11 @@ function raf(el) {
     
     now = _now
 
-    ee.emit('data', dt)
-
     if(!ee.paused) {
-      _raf(iter, el)
+      ee.emit('data', dt)
     }
+    
+    _raf(iter, el)
   }
 }
 


### PR DESCRIPTION
Invoking `pause` didn't actually pause the event stream, it stopped the entire RAF loop. In other words, calling `resume` on a paused stream had no effect. The fix was to place `emit` inside the `paused` check, and move `_raf` out.

I'm not sure if you're satisfied with this solution, or if you'd rather just restart the raf-loop on `resume`. Let me know and I'll update the PR.
