### PR TITLE
Restore node 0.8 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "MIT",
   "devDependencies": {
     "testling": "~1.6.1",
-    "browserify": "~3.46.0",
-    "tape": "~2.11.0"
+    "browserify": "~4.1.2",
+    "tape": "~2.12.3"
   },
   "dependencies": {
     "performance-now": "~0.1.3"


### PR DESCRIPTION
Replace caret with tilde version notation to restore node 0.8 compatibility. Also bumps devDependency versions.
