### PR TITLE
normalize exception behaviour for native raf

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = function(fn) {
   
   return raf.call(global, function () {
     try {
-      fn.call(this, arguments)
+      fn.apply(this, arguments)
     } catch (err) {
       setTimeout(function () {
         throw err


### PR DESCRIPTION
the spec says it should swallow exceptions which is a terrible idea.

This fix checks for whether it's the native version and wraps it in a try catch and re-throws it asynchronously.

This is a temporary work around until the specification is fixed.

See http://lists.w3.org/Archives/Public/public-web-perf/2014Jun/0035.html
