### PR TITLE
Android chokes on the reserved name `native`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var now = require('performance-now')
   , suffix = 'AnimationFrame'
   , raf = global['request' + suffix]
   , caf = global['cancel' + suffix] || global['cancelRequest' + suffix]
-  , native = true
+  , isNative = true
 
 for(var i = 0; i < vendors.length && !raf; i++) {
   raf = global[vendors[i] + 'Request' + suffix]
@@ -14,7 +14,7 @@ for(var i = 0; i < vendors.length && !raf; i++) {
 
 // Some versions of FF have rAF but not cAF
 if(!raf || !caf) {
-  native = false
+  isNative = false
 
   var last = 0
     , id = 0
@@ -64,7 +64,7 @@ module.exports = function(fn) {
   // Wrap in a new function to prevent
   // `cancel` potentially being assigned
   // to the native rAF function
-  if(!native) {
+  if(!isNative) {
     return raf.call(global, fn)
   }
   return raf.call(global, function() {


### PR DESCRIPTION
Here is a reduced example: http://jsbin.com/mutulekugoko/1/.
