### PR TITLE
Add polyfill.js for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ var raf = require('raf')
 
 Shorthand to polyfill `window.requestAnimationFrame` and `window.cancelAnimationFrame` if necessary (Polyfills `global` in node).
 
+Alternatively you can require `raf/polyfill` which will act the same as `require('raf').polyfill()`.
+
 # Acknowledgments
 
 Based on work by Erik Möller, Paul Irish, and Tino Zijdel (https://gist.github.com/paulirish/1579671)

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,1 @@
+require('./').polyfill()


### PR DESCRIPTION
This makes importing the module easier if you only want the polyfill. Especially in es6 modules.

```js
import raf from 'raf'
raf.polyfill()
```

vs

```js
import 'raf/polyfill'
```