### PR TITLE
update dep performance-now to current version && bump version to 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "performance-now": "~2.1.0"
+    "performance-now": "^2.1.0"
   },
   "testling": {
     "files": "test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raf",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "requestAnimationFrame polyfill for node and the browser",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "performance-now": "~0.2.0"
+    "performance-now": "~2.1.0"
   },
   "testling": {
     "files": "test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raf",
-  "version": "3.3.1",
+  "version": "3.3.0",
   "description": "requestAnimationFrame polyfill for node and the browser",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
performance-now had some major changes from 0.2.0 to 2.1.0 that will optimize the performance and stability of raf.
test are passing.
you could think about making this a minor update. i only patched the version to to 3.3.1