### PR TITLE
Add raf.polyfillObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,23 +65,14 @@ The API will be available on `window.raf`.
 
 `handle` is the entry identifier returned by `raf()`. Removes the queued animation frame callback (other queued callbacks will still be invoked unless cancelled).
 
-### raf.polyfill()
+### raf.polyfill([object])
 
 Shorthand to polyfill `window.requestAnimationFrame` and `window.cancelAnimationFrame` if necessary (Polyfills `global` in node).
 
 Alternatively you can require `raf/polyfill` which will act the same as `require('raf').polyfill()`.
 
-### raf.polyfillObject(object)
-
-Polyfill `requestAnimationFrame` and `cancelAnimationFrame` on a given object, instead of the inferred global.
+If you provide `object` the polyfills are attached to that given object, instead of the inferred global.
 Useful if you have an instance of a fake `window` object, and want to add `raf` and `caf` to it.
-
-```js
-const raf = require('raf');
-const myWindow = new JSDOM().window; 
-
-raf.polyfillObject(myWindow);
-```
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ Shorthand to polyfill `window.requestAnimationFrame` and `window.cancelAnimation
 
 Alternatively you can require `raf/polyfill` which will act the same as `require('raf').polyfill()`.
 
+### raf.polyfillObject(object)
+
+Polyfill `requestAnimationFrame` and `cancelAnimationFrame` on a given object, instead of the inferred global.
+Useful if you have an instance of a fake `window` object, and want to add `raf` and `caf` to it.
+
+```js
+const raf = require('raf');
+const myWindow = new JSDOM().window; 
+
+raf.polyfillObject(myWindow);
+```
+
 ## Acknowledgments
 
 Based on work by Erik Möller, Paul Irish, and Tino Zijdel (https://gist.github.com/paulirish/1579671)

--- a/index.js
+++ b/index.js
@@ -66,11 +66,10 @@ module.exports = function(fn) {
 module.exports.cancel = function() {
   caf.apply(root, arguments)
 }
-module.exports.polyfill = function() {
-  root.requestAnimationFrame = raf
-  root.cancelAnimationFrame = caf
-}
-module.exports.polyfillObject = function(object) {
-  object.requestAnimationFrame = raf.bind(object)
-  object.cancelAnimationFrame = caf.bind(object)
+module.exports.polyfill = function(object) {
+  if (!object) {
+    object = root;
+  }
+  object.requestAnimationFrame = raf
+  object.cancelAnimationFrame = caf
 }

--- a/index.js
+++ b/index.js
@@ -70,3 +70,7 @@ module.exports.polyfill = function() {
   root.requestAnimationFrame = raf
   root.cancelAnimationFrame = caf
 }
+module.exports.polyfillObject = function(object) {
+  object.requestAnimationFrame = raf.bind(object)
+  object.cancelAnimationFrame = caf.bind(object)
+}


### PR DESCRIPTION
This makes it easier to add the polyfills from outside of the context.

EDIT: This is probably too naive as the implementation does some checks against `root` which I'd want to be different in my case. Can split it into two files so that I can inject my own `global` I suppose. WDYT?