### PR TITLE
Add support for globalThis

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var now = require('performance-now')
-  , root = typeof window === 'undefined' ? global : window
+  , root = typeof window === 'undefined' ? (typeof global === undefined ? globalThis : global) : window
   , vendors = ['moz', 'webkit']
   , suffix = 'AnimationFrame'
   , raf = root['request' + suffix]


### PR DESCRIPTION
When running this package in a web worker, `window` is undefined - but so is `global`, which causes the browser to throw an error when trying to set `root`

This update adds support for workers by using [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) if `global` is falsey.